### PR TITLE
Correct link to REST-API design

### DIFF
--- a/design/GlusterD2/GD2-Design.md
+++ b/design/GlusterD2/GD2-Design.md
@@ -32,7 +32,7 @@ GD2 will also be a native ReST server, exposing cluster management interfaces vi
 
 The main management interface with GD2 will be a HTTP ReST interface. APIs will be provided for the management of peers, management of volumes, local-GlusterD management, monitoring (events) and long-running asynchronous operations.
 
-More details on the ReST-API can be found [here](ReST-API) (_note that this is still under active development_).
+More details on the ReST-API can be found [here](ReST-API.md) (_note that this is still under active development_).
 
 ### Gluster CLI
 


### PR DESCRIPTION
The link was missing '.md' at the end, leading to a 404.